### PR TITLE
Move RBI download URL to config.yml

### DIFF
--- a/conf/config.yml.dist
+++ b/conf/config.yml.dist
@@ -2,6 +2,7 @@ version: 1.0
 
 config:
   channel: 'stable'
+  rbiurl: 'https://s3-eu-west-1.amazonaws.com/s3.d3nver.io/rbi'
 
 instance:
   name: 'denver'

--- a/fakebin/golint
+++ b/fakebin/golint
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker exec denver_builder golint $*

--- a/src/cmd/root/root.go
+++ b/src/cmd/root/root.go
@@ -159,6 +159,7 @@ func (s *Denver) setVMProvider() (err error) {
 		s.config.Instance,
 		s.config.UserInfo.Userdatasize,
 		s.config.Config.Channel,
+		s.config.Config.RBIURL,
 		s.workingDirectory,
 	); err != nil {
 		return

--- a/src/pkg/providers/providers.go
+++ b/src/pkg/providers/providers.go
@@ -55,11 +55,12 @@ func GetVMProvider(
 	instance *structs.InstanceConf,
 	userDataSize int,
 	channel string,
+	rbiurl string,
 	workingDirectory string,
 ) (VMProvider, error) {
 	switch provider.Hypervisor {
 	case TypeVirtualbox:
-		updater, boxPath, err := getVMUpdater(ctx, workingDirectory, channel, provider.Hypervisor)
+		updater, boxPath, err := getVMUpdater(ctx, workingDirectory, channel, rbiurl, provider.Hypervisor)
 		if err != nil {
 			return nil, err
 		}
@@ -77,7 +78,7 @@ func GetVMProvider(
 	return nil, fmt.Errorf("invalid provider %s", provider.Hypervisor)
 }
 
-func getVMUpdater(ctx context.Context, workingDirectory, channel, hypervisor string) (VMUpdater, string, error) {
+func getVMUpdater(ctx context.Context, workingDirectory, channel, rbiurl, hypervisor string) (VMUpdater, string, error) {
 	switch hypervisor {
 	case TypeVirtualbox:
 		relBoxPath := filepath.Join("store", channel, "box.vdi")
@@ -85,9 +86,9 @@ func getVMUpdater(ctx context.Context, workingDirectory, channel, hypervisor str
 		return virtualbox.NewUpdater(
 			ctx,
 			workingDirectory,
-			fmt.Sprintf("https://s3-eu-west-1.amazonaws.com/s3.d3nver.io/rbi/%s/virtualbox/manifest.json", channel),
+			fmt.Sprintf("%s/%s/virtualbox/manifest.json", rbiurl, channel),
 			filepath.Join("store", channel, "manifest.json"),
-			fmt.Sprintf("https://s3-eu-west-1.amazonaws.com/s3.d3nver.io/rbi/%s/virtualbox/box.vdi.bz2", channel),
+			fmt.Sprintf("%s/%s/virtualbox/box.vdi.bz2", rbiurl, channel),
 			relBoxPath,
 			&http.HTTP{},
 			compressor.NewMultiCompressor(),

--- a/src/structs/structs.go
+++ b/src/structs/structs.go
@@ -30,6 +30,7 @@ type Provider struct {
 // Config : TODO
 type Config struct {
 	Channel string
+	RBIURL  string
 }
 
 // Denver : TODO


### PR DESCRIPTION
Fix #17 (Move RBI download URL to config.yml)

This feature let users host their own Root Base Image on any HTTP(S) webserver.
(RBI builder script will soon be released on GitHub)